### PR TITLE
Fix requirements.txt env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Vscode settings
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -22,7 +22,7 @@ poetry install # it may take a while
 poetry shell
 ```
 Which will install the environment and activate the virtual environment. A `requirements.txt` file is also included 
-if you want to use another virtual environment package. 
+if you want to use another virtual environment package. If you choose to do so, make sure you use a compatible python version (`>=3.7.1,<3.10`) when creating your virtual environment.
 
 At this stage we can also define the environment variables that the application will use.
 Create an `.env` file at the root of the project, copy the template env variables from 

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ pluggy==1.2.0
 progress==1.6
 progressbar2==4.2.0
 prompt-toolkit==3.0.41
-psycopg2==2.9.9
+psycopg2-binary==2.9.9
 ptyprocess==0.7.0
 py==1.11.0
 pycryptodome==3.19.1


### PR DESCRIPTION
This pull request updates the `psycopg2` dependency in the `requirements.txt` file to `psycopg2-binary`. This is needed when creating the virtual environment from a `requirements.txt` file, because building psycopg from source will fail. 
In addition to this change, it adds the `.vscode/` workspace settings folder to .gitignore, and updates the INSTALLATION.md file with instructions for using a compatible python version in the virtual environment, if the user isn't installing the enviroment with poetry.