### PR TITLE
Make Heroku CI deploy opt-in; document deployment options

### DIFF
--- a/.github/workflows/build-deploy-data.yml
+++ b/.github/workflows/build-deploy-data.yml
@@ -64,10 +64,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build -f $DIRECTORY/Dockerfile -t $DIRECTORY-app .
+  # Heroku deploy is opt-in: set the repository variable ENABLE_HEROKU_DEPLOY=true
+  # (plus the HEROKU_* secrets) to enable it. Left unset, master pushes only run
+  # tests and no deploy happens. See the Deployment section of the README.
   build:
     runs-on: ubuntu-latest
     needs: testing
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'
     concurrency: deploy-data
     steps:
       - uses: actions/checkout@v4
@@ -86,7 +89,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'
     environment: production
     concurrency: deploy-data
     steps:

--- a/.github/workflows/build-deploy-execution.yml
+++ b/.github/workflows/build-deploy-execution.yml
@@ -63,10 +63,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker image
         run: docker build -f $DIRECTORY/Dockerfile -t $DIRECTORY-app .
+  # Heroku deploy is opt-in: set the repository variable ENABLE_HEROKU_DEPLOY=true
+  # (plus the HEROKU_* secrets) to enable it. Left unset, master pushes only run
+  # tests and no deploy happens. See the Deployment section of the README.
   build:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'
     concurrency: deploy-execution
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +83,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'
     environment: production
     concurrency: deploy-execution
     steps:

--- a/.github/workflows/build-deploy-model.yml
+++ b/.github/workflows/build-deploy-model.yml
@@ -67,10 +67,13 @@ jobs:
         run: docker build -f $DIRECTORY/Dockerfile.$HEROKU_WEB_PROCESS -t $DIRECTORY-$HEROKU_WEB_PROCESS-app .
       - name: Build worker Docker image
         run: docker build -f $DIRECTORY/Dockerfile.$HEROKU_WORKER_PROCESS -t $DIRECTORY-$HEROKU_WORKER_PROCESS-app .
+  # Heroku deploy is opt-in: set the repository variable ENABLE_HEROKU_DEPLOY=true
+  # (plus the HEROKU_* secrets) to enable it. Left unset, master pushes only run
+  # tests and no deploy happens. See the Deployment section of the README.
   build:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'
     concurrency: deploy-model
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +87,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'
     environment: production
     concurrency: deploy-model
     steps:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -180,6 +180,18 @@ AWS_SECRET_ACCESS_KEY # Your Personal AWS secret access key
 AWS_BUCKET # The name of the bucket where you'll keep you files
 ```
 
+The Heroku deploy jobs in the CI workflows are **opt-in**: they only run when a
+repository *variable* (not secret) named `ENABLE_HEROKU_DEPLOY` is set to `true`.
+On the same settings page, open the `Variables` tab and add:
+
+```shell
+ENABLE_HEROKU_DEPLOY # Set to "true" to deploy to Heroku on pushes to master
+```
+
+If this variable is unset (the default), pushes to `master` only run the test
+suite and build the Docker images — no deployment happens. This lets you fork
+the repo and run CI without it trying to deploy to a Heroku account.
+
 Then, navigate to the tab `Actions` and click on `I understand my workflows, go ahead and enable them`. We can now
 trigger the workflows on Github actions required to deploy our apps onto Heroku. We can achieve that by sending a 
 request to the Github API as shown below:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ The detailed steps for installing and using this application locally and remotel
 diving into the installation steps.
 
 
+## Deployment
+
+MyCryptoBot can be run in a few ways:
+
+- **Locally** — `docker-compose up --build` brings up all services on your machine
+  (see [INSTALLATION.md](INSTALLATION.md)).
+- **On your own server** — clone the repo on any VPS and run the same `docker-compose`
+  stack; pull and rebuild to update.
+- **On Heroku** — the repository ships with GitHub Actions workflows that build and
+  release each service to Heroku. This is **opt-in**: set the repository variable
+  `ENABLE_HEROKU_DEPLOY=true` (plus the `HEROKU_*` secrets) to deploy on pushes to
+  `master`. Left unset, CI only runs the tests and builds the images — nothing is
+  deployed. See the [Github](INSTALLATION.md#github) section of the installation guide.
+
+
 ## Introduction
 
 The primary goal of this repository is to provide a platform that enables you to deploy your strategies, 


### PR DESCRIPTION
## Summary

The `build`/`deploy` jobs in the three service workflows ran on every push to `master`, so a repo owner's pushes always deployed to *their* Heroku account (the deploy targets whatever `HEROKU_*` secrets are set in the repo). This makes that deployment **opt-in** instead.

- Gate the `build` and `deploy` jobs behind `github.ref == 'refs/heads/master' && vars.ENABLE_HEROKU_DEPLOY == 'true'`. Unset (the default), pushes to `master` only run tests and build images — no deploy. Set to `'true'` (with the `HEROKU_*` secrets), the ready-made Heroku deploy still works.
- Add a self-documenting comment above each `build` job.
- Document the new `ENABLE_HEROKU_DEPLOY` repository **variable** in `INSTALLATION.md`, and add a **Deployment** section to the README (local / self-hosted / Heroku).

No deploy jobs are removed — the Heroku path stays available for anyone who forks the repo and opts in.

## Effect
- Owner: leave `ENABLE_HEROKU_DEPLOY` unset → pushes no longer auto-deploy to Heroku.
- Forkers: set the variable + their own secrets → deploy works as before.

## Test plan
- [x] Workflows are valid YAML; `test`/`test-build` jobs unchanged
- [x] Diff is config + docs only (no app code)